### PR TITLE
fix: typo in `role_definitions` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1556,7 +1556,7 @@ Description: A map of Azure Resource Manager role assignments. The key is the ke
 * `principal_id`: The principal id (object id) of the user, group, service principal, or managed identity the role assignment is for.
 * `scope`: The scope of the role assignment.
 
-### <a name="output_role_defintions"></a> [role\_defintions](#output\_role\_defintions)
+### <a name="output_role_definitions"></a> [role\_definitions](#output\_role\_definitions)
 
 Description: A map of Azure Resource Manager role definitions. The key is the key you supplied and the value consists of is the role definition id and the allowed scopes.
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -181,7 +181,7 @@ Description: Entra ID groups
 
 Description: Azure Resource Manager role assignments
 
-### <a name="output_role_defintions"></a> [role\_defintions](#output\_role\_defintions)
+### <a name="output_role_definitions"></a> [role\_definitions](#output\_role\_definitions)
 
 Description: Azure Resource Manager role definitions
 

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -28,9 +28,9 @@ output "role_assignments" {
   value       = module.role_assignments.role_assignments
 }
 
-output "role_defintions" {
+output "role_definitions" {
   description = "Azure Resource Manager role definitions"
-  value       = module.role_assignments.role_defintions
+  value       = module.role_assignments.role_definitions
 }
 
 output "system_assigned_managed_identities" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,7 +46,7 @@ DESCRIPTION
   value       = local.role_assignments
 }
 
-output "role_defintions" {
+output "role_definitions" {
   description = "A map of Azure Resource Manager role definitions. The key is the key you supplied and the value consists of is the role definition id and the allowed scopes."
   value       = local.role_definitions
 }


### PR DESCRIPTION
Fixes #101

## Description

Renamed output `role_defintions` to `role_definitions` (missing letter "i" in the original name).

Updated:
- `outputs.tf` (root module output name)
- `examples/default/outputs.tf` (example output name + value reference)
- `README.md` and `examples/default/README.md` (auto-generated docs)

This is a **breaking change** for users referencing `module.xxx.role_defintions` — they will need to update to `module.xxx.role_definitions`.

Original contribution by @tobiasehlert in #107.

## Type of Change

- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #101" in the PR description.
  - [x] Update to documentation